### PR TITLE
Fix: download both videos and images (+PEP8 auto format)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,77 +1,90 @@
 #!/usr/bin/env python3
 import json
-from bs4 import BeautifulSoup
-import requests
-import re
-import wget
-import os
 import logging
+import os
+import re
 import sys
+from collections import namedtuple
+from typing import List
+
+import requests
+import wget
+
+Media = namedtuple('Media', 'source_type url')
 
 logging.basicConfig(level=logging.INFO)
 image_counter = 0
 video_counter = 0
 
+
 def download_content(uid, username):
-    url = "https://www.instagram.com/p/"+str(uid)
-    html_doc = requests.get(url,headers=headers,timeout=5).text
-    try:
-        download_video(html_doc, username)
-    except:
-        download_img(html_doc, username)
+    url = f"https://www.instagram.com/p/{uid}"
+    html_doc = requests.get(url, headers=headers, timeout=5).text
+    # download both images and videos
+    download_medias(html_doc, username)
 
-def download_video(html_doc,username):
-    result = re.search('"og:video" content="(.*)"', html_doc)
-    link = result.group(1)
-    logging.info('Downloading Video')
-    name=wget.download(link,'POSTS/'+username+'/')
-    logging.info(name)
-    global video_counter
-    video_counter += 1
 
-def download_img(html_doc,username):
-    img_list = []
-    json_data = re.search('window._sharedData = (.*);</script>',html_doc).group(1)
-    d = json.loads(json_data)
+def download_medias(html_doc, username):
     global image_counter
-    co =0
-    while True:
-        try:
-            img_list.append(d["entry_data"]["PostPage"][0]["graphql"]["shortcode_media"]["edge_sidecar_to_children"]["edges"][co]["node"]["display_url"])
-            co+=1
-        except:
-            break
-    if not img_list:
-        result = re.search('"og:image" content="(.*)"', html_doc)
-        link = result.group(1)
-        logging.info('Downloading Image')
-        name=wget.download(link,'POSTS/'+username+'/')
-        logging.info("\n"+name)
-        image_counter += 1
+    global video_counter
+    # collector of media urls (could be both images and videos)
+    media_list: List[Media] = []
+    # parse the returned html body response and loads it as a json string
+    json_string = re.search('window._sharedData = (.*);</script>', html_doc).group(1)
+    as_json = json.loads(json_string)
+    # identify the json entry we have to work with
+    entry = as_json["entry_data"]["PostPage"][0]["graphql"]["shortcode_media"]
+    # look for key 'edge_sidecar_to_children' (multiple images/videos)
+    if 'edge_sidecar_to_children' in entry:
+        # find edges
+        sidecar_edges = entry["edge_sidecar_to_children"]["edges"]
+        sidecar_edges = [edge for edge in sidecar_edges]
+        # find nodes
+        sidecar_nodes = [edge['node'] for edge in sidecar_edges]
+        # loop over nodes and collect images and videos
+        for node in sidecar_nodes:
+            if node['is_video']:
+                media_list.append(Media(source_type='video', url=node['video_url']))
+            else:
+                media_list.append(Media(source_type='image', url=node['display_url']))
     else:
-        for link in img_list:
-            logging.info('Downloading Image')
-            name=wget.download(link,'POSTS/'+username+'/')
-            logging.info("\n"+name)
+        # must be a single media
+        if entry['is_video']:
+            media_list.append(Media(source_type='video', url=entry['video_url']))
+        else:
+            media_list.append(Media(source_type='image', url=entry['display_url']))
+
+    for source_type, url in media_list:
+        logging.info(f'Downloading {source_type} from {url}')
+        name = wget.download(url, 'POSTS/' + username + '/')
+        logging.info("\n" + name)
+
+        if source_type == 'video':
+            video_counter += 1
+        else:
             image_counter += 1
 
+
 def get_end_cursor(uid):
-    url = "https://www.instagram.com/p/"+str(uid)
-    user_doc = requests.get(url,headers=headers,timeout=5).text
-    json_data = re.search('window._sharedData = (.*);</script>',user_doc).group(1)
+    url = "https://www.instagram.com/p/" + str(uid)
+    user_doc = requests.get(url, headers=headers, timeout=5).text
+    json_data = re.search('window._sharedData = (.*);</script>', user_doc).group(1)
     d = json.loads(json_data)
-    end_cursor = str(d['entry_data']['PostPage'][0]['graphql']['shortcode_media']['edge_media_to_parent_comment']['page_info']['end_cursor'])
+    end_cursor = str(
+        d['entry_data']['PostPage'][0]['graphql']['shortcode_media']['edge_media_to_parent_comment']['page_info'][
+            'end_cursor'])
     return end_cursor
 
-def get_link_by_end(after,idd,query_hash):
-    url = 'https://www.instagram.com/graphql/query/?query_hash='+query_hash+'&variables={"id":"'+idd+'","first":50,"after":"'+after+'"}'
-    user_doc = requests.get(url,headers=headers).text
+
+def get_link_by_end(after, idd, query_hash):
+    url = 'https://www.instagram.com/graphql/query/?query_hash=' + query_hash + '&variables={"id":"' + idd + '","first":50,"after":"' + after + '"}'
+    user_doc = requests.get(url, headers=headers).text
     user_doc = json.loads(user_doc)
-    links =[]
+    links = []
     for i in range(50):
         links.append(str(user_doc['data']['user']['edge_owner_to_timeline_media']['edges'][i]['node']['shortcode']))
-    new_endlink= str(user_doc['data']['user']['edge_owner_to_timeline_media']['page_info']['end_cursor'])
-    return links,new_endlink
+    new_endlink = str(user_doc['data']['user']['edge_owner_to_timeline_media']['page_info']['end_cursor'])
+    return links, new_endlink
 
 
 headers = {
@@ -91,17 +104,19 @@ try:
     except:
         pass
     try:
-       os.mkdir('POSTS/'+username+'/')
+        os.mkdir('POSTS/' + username + '/')
     except:
-	    pass
-    url = "https://www.instagram.com/"+username
-    user_doc = requests.get(url,headers=headers).text
-    json_data = re.search('window._sharedData = (.*);</script>',user_doc).group(1)
+        pass
+    url = "https://www.instagram.com/" + username
+    user_doc = requests.get(url, headers=headers).text
+    json_data = re.search('window._sharedData = (.*);</script>', user_doc).group(1)
     d = json.loads(json_data)
     account_id = str(d['entry_data']['ProfilePage'][0]['graphql']['user']['id'])
-    end_cursor = str(d['entry_data']['ProfilePage'][0]['graphql']['user']['edge_owner_to_timeline_media']['page_info']['end_cursor'])
-    uid= d['entry_data']['ProfilePage'][0]['graphql']['user']['edge_owner_to_timeline_media']['edges'][0]['node']['shortcode']
-    sency,endlink=get_link_by_end(get_end_cursor(uid),account_id,query_hash)
+    end_cursor = str(
+        d['entry_data']['ProfilePage'][0]['graphql']['user']['edge_owner_to_timeline_media']['page_info']['end_cursor'])
+    uid = d['entry_data']['ProfilePage'][0]['graphql']['user']['edge_owner_to_timeline_media']['edges'][0]['node'][
+        'shortcode']
+    sency, endlink = get_link_by_end(get_end_cursor(uid), account_id, query_hash)
     while True:
         for k in sency:
             try:
@@ -109,7 +124,7 @@ try:
             except requests.exceptions.ReadTimeout:
                 logging.info("Download Failed!!")
         try:
-            sency,endlink=get_link_by_end(endlink,account_id,query_hash)
+            sency, endlink = get_link_by_end(endlink, account_id, query_hash)
         except requests.exceptions.ReadTimeout:
             logging.info("End link fetching failed!!")
 except requests.exceptions.ReadTimeout:


### PR DESCRIPTION
Issue: https://github.com/IamStefin/Instagram-Image-Downloader/issues/6

Added a new function "download_medias" that handles both images and videos.

I think dealing with og:video tags is a bit weird because when there is a "slider", there are no og:video tags in the response.

Also, I saw a room for improvements but I didn't want to overload this pull request.